### PR TITLE
Add discrete GPU support for NVIDIA drivers

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -111,7 +111,7 @@ Recommends: bolt (>= 0.3),
             gnome-user-docs,
             ibus,
             iio-sensor-proxy,
-            switcheroo-control,
+            switcheroo-control (>= 2.0),
             ubuntu-session | gnome-session,
             xserver-xorg-legacy,
             unzip

--- a/debian/control.in
+++ b/debian/control.in
@@ -107,7 +107,7 @@ Recommends: bolt (>= 0.3),
             gnome-user-docs,
             ibus,
             iio-sensor-proxy,
-            switcheroo-control,
+            switcheroo-control (>= 2.0),
             ubuntu-session | gnome-session,
             xserver-xorg-legacy,
             unzip

--- a/debian/patches/ignore-nvidia-only.patch
+++ b/debian/patches/ignore-nvidia-only.patch
@@ -1,0 +1,46 @@
+--- a/js/ui/appDisplay.js
++++ b/js/ui/appDisplay.js
+@@ -2497,7 +2497,10 @@
+                 this._appendSeparator();
+             }
+ 
++            let vendor = Shell.util_get_gl_vendor();
+             if (discreteGpuAvailable &&
++                vendor != "NVIDIA Corporation" &&
++                vendor != "nouveau" &&
+                 this._source.app.state == Shell.AppState.STOPPED) {
+                 this._onDiscreteGpuMenuItem = this._appendMenuItem(_("Launch using Dedicated Graphics Card"));
+                 this._onDiscreteGpuMenuItem.connect('activate', () => {
+--- a/src/shell-util.c
++++ b/src/shell-util.c
+@@ -379,8 +379,8 @@
+ 
+ typedef const gchar *(*ShellGLGetString) (GLenum);
+ 
+-static const gchar *
+-get_gl_vendor (void)
++const gchar *
++shell_util_get_gl_vendor (void)
+ {
+   static const gchar *vendor = NULL;
+ 
+@@ -401,7 +401,7 @@
+   if (!clutter_check_windowing_backend (CLUTTER_WINDOWING_X11))
+     return FALSE;
+ 
+-  if (g_strcmp0 (get_gl_vendor (), "NVIDIA Corporation") == 0)
++  if (g_strcmp0 (shell_util_get_gl_vendor (), "NVIDIA Corporation") == 0)
+     return TRUE;
+ 
+   return FALSE;
+--- a/src/shell-util.h
++++ b/src/shell-util.h
+@@ -44,6 +44,8 @@
+                                                int                height,
+                                                int                rowstride);
+ 
++const gchar *shell_util_get_gl_vendor (void);
++
+ gboolean shell_util_need_background_refresh (void);
+ 
+ ClutterContent * shell_util_get_content_for_window_actor (MetaWindowActor *window_actor,

--- a/debian/patches/nvidia-offloading.patch
+++ b/debian/patches/nvidia-offloading.patch
@@ -1,0 +1,351 @@
+--- a/data/dbus-interfaces/net.hadess.SwitcherooControl.xml
++++ b/data/dbus-interfaces/net.hadess.SwitcherooControl.xml
+@@ -1,5 +1,46 @@
++<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
++"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
++
+ <node>
++
++  <!--
++      net.hadess.SwitcherooControl:
++      @short_description: D-Bus proxy to access dual-GPU controls.
++
++      After checking the availability of two switchable GPUs in the machine,
++      check the value of net.hadess.SwitcherooControl.HasDualGpu to see
++      if running applications on the discrete GPU should be offered.
++
++      The object path will be "/net/hadess/SwitcherooControl".
++  -->
+   <interface name="net.hadess.SwitcherooControl">
++    <!--
++        HasDualGpu:
++
++        Whether two switchable GPUs are present on the system. This property
++        has been obsoleted in favour of the "NumGPUs" property.
++    -->
+     <property name="HasDualGpu" type="b" access="read"/>
++
++    <!--
++        NumGPUs:
++
++        The number of GPUs available on the system. Note that while having no
++        GPUs is unlikely, consumers of this API should probably not throw errors
++        if that were the case.
++    -->
++    <property name="NumGPUs" type="u" access="read"/>
++
++    <!--
++        GPUs:
++
++        An array of key-pair values representing each GPU. The key named "Name" (s)
++        will contain a user-facing name for the GPU, the "Environment" (as) key will
++        contain an array of even number of strings, each being an environment
++        variable to set to use the GPU, followed by its value, the "Default" (b) key
++        will tag the default (usually integrated) GPU.
++    -->
++    <property name="GPUs" type="aa{sv}" access="read"/>
++
+   </interface>
+ </node>
+--- a/js/ui/appDisplay.js
++++ b/js/ui/appDisplay.js
+@@ -2444,8 +2444,7 @@
+             }
+ 
+             if (discreteGpuAvailable &&
+-                this._source.app.state == Shell.AppState.STOPPED &&
+-                !actions.includes('activate-discrete-gpu')) {
++                this._source.app.state == Shell.AppState.STOPPED) {
+                 this._onDiscreteGpuMenuItem = this._appendMenuItem(_("Launch using Dedicated Graphics Card"));
+                 this._onDiscreteGpuMenuItem.connect('activate', () => {
+                     this._source.animateLaunch();
+@@ -2458,8 +2457,7 @@
+                 let action = actions[i];
+                 let item = this._appendMenuItem(appInfo.get_action_name(action));
+                 item.connect('activate', (emitter, event) => {
+-                    if (action == 'new-window' ||
+-                        action == 'activate-discrete-gpu')
++                    if (action == 'new-window')
+                         this._source.animateLaunch();
+ 
+                     this._source.app.launch_action(action, event.get_time(), -1);
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -188,6 +188,11 @@
+   namespace: 'Shell'
+ )
+ 
++dbus_generated += gnome.gdbus_codegen('switcheroo-control',
++  '../data/dbus-interfaces/net.hadess.SwitcherooControl.xml',
++  namespace: 'Shell'
++)
++
+ libshell_no_gir_sources += dbus_generated
+ 
+ libshell = library('gnome-shell',
+--- a/src/shell-global.c
++++ b/src/shell-global.c
+@@ -44,6 +44,7 @@
+ #include "shell-window-tracker.h"
+ #include "shell-wm.h"
+ #include "st.h"
++#include "switcheroo-control.h"
+ 
+ static ShellGlobal *the_object = NULL;
+ 
+@@ -82,6 +83,9 @@
+   gboolean has_modal;
+   gboolean frame_timestamps;
+   gboolean frame_finish_timestamp;
++
++  GDBusProxy *switcheroo_control;
++  GCancellable *switcheroo_cancellable;
+ };
+ 
+ enum {
+@@ -104,6 +108,7 @@
+   PROP_FRAME_TIMESTAMPS,
+   PROP_FRAME_FINISH_TIMESTAMP,
+   PROP_DEBUG_FLAGS,
++  PROP_SWITCHEROO_CONTROL,
+ };
+ 
+ /* Signals */
+@@ -119,6 +124,72 @@
+ static guint shell_global_signals [LAST_SIGNAL] = { 0 };
+ 
+ static void
++got_switcheroo_control_gpus_property_cb (GObject      *source_object,
++                                         GAsyncResult *res,
++                                         gpointer      user_data)
++{
++  ShellGlobal *global;
++  GError *error = NULL;
++  GVariant *gpus;
++
++  gpus = g_dbus_connection_call_finish (G_DBUS_CONNECTION (source_object),
++                                        res, &error);
++  if (!gpus)
++    {
++      if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
++        g_debug ("Could not get GPUs property from switcheroo-control: %s", error->message);
++      g_clear_error (&error);
++      return;
++    }
++
++  global = user_data;
++  g_dbus_proxy_set_cached_property (global->switcheroo_control, "GPUs", gpus);
++}
++
++static void
++switcheroo_control_ready_cb (GObject      *source_object,
++                             GAsyncResult *res,
++                             gpointer      user_data)
++{
++  ShellGlobal *global;
++  GError *error = NULL;
++  ShellNetHadessSwitcherooControl *control;
++  g_auto(GStrv) cached_props = NULL;
++
++  control = shell_net_hadess_switcheroo_control_proxy_new_for_bus_finish (res, &error);
++  if (!control)
++    {
++      if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
++        g_debug ("Could not get switcheroo-control GDBusProxy: %s", error->message);
++      g_clear_error (&error);
++      return;
++    }
++
++  global = user_data;
++  global->switcheroo_control = G_DBUS_PROXY (control);
++  g_debug ("Got switcheroo-control proxy successfully");
++
++  cached_props = g_dbus_proxy_get_cached_property_names (global->switcheroo_control);
++  if (cached_props != NULL && g_strv_contains ((const gchar * const *) cached_props, "GPUs"))
++    return;
++
++  g_dbus_connection_call (g_dbus_proxy_get_connection (global->switcheroo_control),
++                          g_dbus_proxy_get_name (global->switcheroo_control),
++                          g_dbus_proxy_get_object_path (global->switcheroo_control),
++                          "org.freedesktop.DBus.Properties",
++                          "Get",
++                          g_variant_new ("(ss)",
++                                         g_dbus_proxy_get_interface_name (global->switcheroo_control),
++                                         "GPUs"),
++                          NULL,
++                          G_DBUS_CALL_FLAGS_NONE,
++                          -1,
++                          global->switcheroo_cancellable,
++                          got_switcheroo_control_gpus_property_cb,
++                          user_data);
++}
++
++static void
+ shell_global_set_property(GObject         *object,
+                           guint            prop_id,
+                           const GValue    *value,
+@@ -218,6 +289,9 @@
+     case PROP_DEBUG_FLAGS:
+       g_value_set_string (value, global->debug_flags);
+       break;
++    case PROP_SWITCHEROO_CONTROL:
++      g_value_set_object (value, global->switcheroo_control);
++      break;
+     default:
+       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+       break;
+@@ -317,6 +391,15 @@
+   global->save_ops = g_hash_table_new_full (g_file_hash,
+                                             (GEqualFunc) g_file_equal,
+                                             g_object_unref, g_object_unref);
++
++  global->switcheroo_cancellable = g_cancellable_new ();
++  shell_net_hadess_switcheroo_control_proxy_new_for_bus (G_BUS_TYPE_SYSTEM,
++                                                         G_DBUS_PROXY_FLAGS_NONE,
++                                                         "net.hadess.SwitcherooControl",
++                                                         "/net/hadess/SwitcherooControl",
++                                                         global->switcheroo_cancellable,
++                                                         switcheroo_control_ready_cb,
++                                                         global);
+ }
+ 
+ static void
+@@ -329,6 +412,9 @@
+ 
+   the_object = NULL;
+ 
++  g_cancellable_cancel (global->switcheroo_cancellable);
++  g_clear_object (&global->switcheroo_cancellable);
++
+   g_clear_object (&global->userdatadir_path);
+   g_clear_object (&global->runtime_state_path);
+ 
+@@ -492,6 +578,13 @@
+                                                         "The debugging flags",
+                                                         NULL,
+                                                         G_PARAM_READWRITE));
++  g_object_class_install_property (gobject_class,
++                                   PROP_SWITCHEROO_CONTROL,
++                                   g_param_spec_object ("switcheroo-control",
++                                                        "switcheroo-control",
++                                                        "D-Bus Proxy for switcheroo-control daemon",
++                                                        G_TYPE_DBUS_PROXY,
++                                                        G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
+ }
+ 
+ /*
+@@ -1276,6 +1369,22 @@
+ }
+ 
+ /**
++ * _shell_global_get_switcheroo_control: (skip)
++ * @global: A #ShellGlobal
++ *
++ * Get the global #GDBusProxy instance for the switcheroo-control
++ * daemon.
++ *
++ * Return value: (transfer none): the #GDBusProxy for the daemon,
++ *   or %NULL on error.
++ */
++GDBusProxy *
++_shell_global_get_switcheroo_control    (ShellGlobal  *global)
++{
++  return global->switcheroo_control;
++}
++
++/**
+  * shell_global_get_settings:
+  * @global: A #ShellGlobal
+  *
+--- a/src/shell-global.h
++++ b/src/shell-global.h
+@@ -66,6 +66,9 @@
+ /* Misc utilities / Shell API */
+ void     shell_global_sync_pointer              (ShellGlobal  *global);
+ 
++GDBusProxy *
++         _shell_global_get_switcheroo_control   (ShellGlobal  *global);
++
+ GAppLaunchContext *
+          shell_global_create_app_launch_context (ShellGlobal  *global,
+                                                  guint32       timestamp,
+--- a/src/shell-app.c
++++ b/src/shell-app.c
+@@ -19,6 +19,7 @@
+ #include "st.h"
+ #include "gtkactionmuxer.h"
+ #include "org-gtk-application.h"
++#include "switcheroo-control.h"
+ 
+ #ifdef HAVE_SYSTEMD
+ #include <systemd/sd-journal.h>
+@@ -1255,6 +1256,60 @@
+   g_child_watch_add (pid, (GChildWatchFunc) g_spawn_close_pid, NULL);
+ }
+ 
++static void
++apply_discrete_gpu_env (GAppLaunchContext *context,
++                        ShellGlobal       *global)
++{
++  GDBusProxy *proxy;
++  GVariant* variant;
++  guint num_children, i;
++
++  proxy = _shell_global_get_switcheroo_control (global);
++  if (!proxy)
++    {
++      g_warning ("Could not apply discrete GPU environment, switcheroo-control not available");
++      return;
++    }
++
++  variant = shell_net_hadess_switcheroo_control_get_gpus (SHELL_NET_HADESS_SWITCHEROO_CONTROL (proxy));
++  if (!variant)
++    {
++      g_warning ("Could not apply discrete GPU environment, no GPUs in list");
++      return;
++    }
++
++  num_children = g_variant_n_children (variant);
++  for (i = 0; i < num_children; i++)
++    {
++      g_autoptr(GVariant) gpu;
++      g_autoptr(GVariant) env = NULL;
++      g_autoptr(GVariant) default_variant = NULL;
++      g_autofree const char **env_s = NULL;
++      guint j;
++
++      gpu = g_variant_get_child_value (variant, i);
++      if (!gpu ||
++          !g_variant_is_of_type (gpu, G_VARIANT_TYPE ("a{s*}")))
++        continue;
++
++      /* Skip over the default GPU */
++      default_variant = g_variant_lookup_value (gpu, "Default", NULL);
++      if (!default_variant || g_variant_get_boolean (default_variant))
++        continue;
++
++      env = g_variant_lookup_value (gpu, "Environment", NULL);
++      if (!env)
++        continue;
++
++      env_s = g_variant_get_strv (env, NULL);
++      for (j = 0; env_s[j] != NULL; j = j + 2)
++        g_app_launch_context_setenv (context, env_s[j], env_s[j+1]);
++      return;
++    }
++
++  g_warning ("Could not find discrete GPU data in switcheroo-control");
++}
++
+ /**
+  * shell_app_launch:
+  * @timestamp: Event timestamp, or 0 for current event timestamp
+@@ -1290,7 +1345,7 @@
+   global = shell_global_get ();
+   context = shell_global_create_app_launch_context (global, timestamp, workspace);
+   if (discrete_gpu)
+-    g_app_launch_context_setenv (context, "DRI_PRIME", "1");
++    apply_discrete_gpu_env (context, global);
+ 
+   /* Set LEAVE_DESCRIPTORS_OPEN in order to use an optimized gspawn
+    * codepath. The shell's open file descriptors should be marked CLOEXEC

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -20,3 +20,4 @@ ubuntu/secure_mode_extension.patch
 # Pop!_OS
 pop-dark-theme.patch
 sched-rr.patch
+nvidia-offloading.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -21,3 +21,4 @@ ubuntu/secure_mode_extension.patch
 pop-dark-theme.patch
 sched-rr.patch
 nvidia-offloading.patch
+ignore-nvidia-only.patch


### PR DESCRIPTION
Use data from switcheroo-control to know which environment variables to use to launch an application on the discrete GPU. switcheroo-control version 2.0 or newer should be installed on Linux platforms.

This adds the right click menu "Launch using Dedicated Graphics Card" when using the NVIDIA proprietary drivers.

https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/781