### PR TITLE
focal: Add persistent GPU offloading

### DIFF
--- a/debian/patches/pop-always-launch-dgpu.patch
+++ b/debian/patches/pop-always-launch-dgpu.patch
@@ -1,0 +1,139 @@
+Index: gnome-shell/js/ui/appDisplay.js
+===================================================================
+--- gnome-shell.orig/js/ui/appDisplay.js	2020-04-10 14:10:23.625960722 -0600
++++ gnome-shell/js/ui/appDisplay.js	2020-04-10 14:21:09.263972778 -0600
+@@ -2478,10 +2478,19 @@
+ 
+             if (discreteGpuAvailable &&
+                 this._source.app.state == Shell.AppState.STOPPED) {
+-                this._onDiscreteGpuMenuItem = this._appendMenuItem(_("Launch using Dedicated Graphics Card"));
+-                this._onDiscreteGpuMenuItem.connect('activate', () => {
++                let text = _("Launch using Dedicated Graphics Card");
++                let selection = Shell.AppGpuSelection.DISCRETE;
++
++                let wantsDiscreteGpu = appInfo.get_boolean("X-KDE_RunOnDiscreteGpu");
++                if (wantsDiscreteGpu) {
++                    text =_("Launch using Integrated Graphics Card");
++                    selection = Shell.AppGpuSelection.INTEGRATED;
++                }
++
++                this._onGpuMenuItem = this._appendMenuItem(text);
++                this._onGpuMenuItem.connect('activate', () => {
+                     this._source.animateLaunch();
+-                    this._source.app.launch(0, -1, true);
++                    this._source.app.launch(0, -1, selection);
+                     this.emit('activate-window', null);
+                 });
+             }
+Index: gnome-shell/src/shell-app.c
+===================================================================
+--- gnome-shell.orig/src/shell-app.c	2020-04-10 14:10:23.653962554 -0600
++++ gnome-shell/src/shell-app.c	2020-04-10 14:18:10.529462339 -0600
+@@ -524,7 +524,7 @@
+       case SHELL_APP_STATE_STOPPED:
+         {
+           GError *error = NULL;
+-          if (!shell_app_launch (app, timestamp, workspace, FALSE, &error))
++          if (!shell_app_launch (app, timestamp, workspace, SHELL_APP_GPU_SELECTION_AUTO, &error))
+             {
+               char *msg;
+               msg = g_strdup_printf (_("Failed to launch “%s”"), shell_app_get_name (app));
+@@ -599,7 +599,7 @@
+    * instance (Firefox).  There are a few less-sensical cases such
+    * as say Pidgin.
+    */
+-  shell_app_launch (app, 0, workspace, FALSE, NULL);
++  shell_app_launch (app, 0, workspace, SHELL_APP_GPU_SELECTION_AUTO, NULL);
+ }
+ 
+ /**
+@@ -1270,6 +1270,23 @@
+   g_child_watch_add (pid, (GChildWatchFunc) g_spawn_close_pid, NULL);
+ }
+ 
++static gboolean
++get_with_discrete_gpu (ShellApp             *app,
++                       ShellAppGpuSelection  discrete_gpu)
++{
++  switch (discrete_gpu)
++    {
++      case SHELL_APP_GPU_SELECTION_INTEGRATED:
++        return FALSE;
++      case SHELL_APP_GPU_SELECTION_DISCRETE:
++        return TRUE;
++      case SHELL_APP_GPU_SELECTION_AUTO:
++        return g_desktop_app_info_get_boolean (app->info, "X-KDE-RunOnDiscreteGpu");
++      default:
++        g_assert_not_reached ();
++    }
++}
++
+ static void
+ apply_discrete_gpu_env (GAppLaunchContext *context,
+                         ShellGlobal       *global)
+@@ -1328,15 +1345,15 @@
+  * shell_app_launch:
+  * @timestamp: Event timestamp, or 0 for current event timestamp
+  * @workspace: Start on this workspace, or -1 for default
+- * @discrete_gpu: Whether to start on the discrete GPU
++ * @discrete_gpu: The preferred GPU to launch the application on
+  * @error: A #GError
+  */
+ gboolean
+-shell_app_launch (ShellApp     *app,
+-                  guint         timestamp,
+-                  int           workspace,
+-                  gboolean      discrete_gpu,
+-                  GError      **error)
++shell_app_launch (ShellApp              *app,
++                  guint                  timestamp,
++                  int                    workspace,
++                  ShellAppGpuSelection   discrete_gpu,
++                  GError               **error)
+ {
+   ShellGlobal *global;
+   GAppLaunchContext *context;
+@@ -1358,7 +1375,8 @@
+ 
+   global = shell_global_get ();
+   context = shell_global_create_app_launch_context (global, timestamp, workspace);
+-  if (discrete_gpu)
++  /* FIXME: this should probably check whether we're on a dual-GPU system */
++  if (get_with_discrete_gpu (app, discrete_gpu))
+     apply_discrete_gpu_env (context, global);
+ 
+   /* Set LEAVE_DESCRIPTORS_OPEN in order to use an optimized gspawn
+Index: gnome-shell/src/shell-app.h
+===================================================================
+--- gnome-shell.orig/src/shell-app.h	2020-03-30 10:16:16.219058085 -0600
++++ gnome-shell/src/shell-app.h	2020-04-10 14:14:56.513123488 -0600
+@@ -18,6 +18,12 @@
+   SHELL_APP_STATE_RUNNING
+ } ShellAppState;
+ 
++typedef enum {
++  SHELL_APP_GPU_SELECTION_AUTO       = -1,
++  SHELL_APP_GPU_SELECTION_INTEGRATED = 0,
++  SHELL_APP_GPU_SELECTION_DISCRETE   = 1,
++} ShellAppGpuSelection;
++
+ const char *shell_app_get_id (ShellApp *app);
+ 
+ GDesktopAppInfo *shell_app_get_app_info (ShellApp *app);
+@@ -51,11 +57,11 @@
+ 
+ gboolean shell_app_is_on_workspace (ShellApp *app, MetaWorkspace *workspace);
+ 
+-gboolean shell_app_launch (ShellApp     *app,
+-                           guint         timestamp,
+-                           int           workspace,
+-                           gboolean      discrete_gpu,
+-                           GError      **error);
++gboolean shell_app_launch (ShellApp              *app,
++                           guint                  timestamp,
++                           int                    workspace,
++                           ShellAppGpuSelection   discrete_gpu,
++                           GError               **error);
+ 
+ void shell_app_launch_action (ShellApp        *app,
+                               const char      *action_name,

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -23,3 +23,4 @@ ubuntu/resolve_alternate_theme_path.patch
 ubuntu/secure_mode_extension.patch
 sched-rr.patch
 pop-dark-theme.patch
+pop-always-launch-dgpu.patch


### PR DESCRIPTION
When `X-KDE-RunOnDiscreteGpu` is set in the application's .desktop file, launch the application on the discrete GPU if available, and provide the option to launch on the integrated GPU.

See also: #14 