### PR TITLE
focal: Don't show dGPU launch item if backed by NVIDIA

### DIFF
--- a/debian/patches/ignore-nvidia-only.patch
+++ b/debian/patches/ignore-nvidia-only.patch
@@ -1,0 +1,52 @@
+Index: gnome-shell/js/ui/appDisplay.js
+===================================================================
+--- gnome-shell.orig/js/ui/appDisplay.js	2020-04-20 11:05:31.673300893 -0600
++++ gnome-shell/js/ui/appDisplay.js	2020-04-20 11:08:07.038630275 -0600
+@@ -2504,7 +2504,10 @@
+                 this._appendSeparator();
+             }
+ 
++            let vendor = Shell.util_get_gl_vendor();
+             if (discreteGpuAvailable &&
++                vendor != "NVIDIA Corporation" &&
++                vendor != "nouveau" &&
+                 this._source.app.state == Shell.AppState.STOPPED) {
+                 this._onDiscreteGpuMenuItem = this._appendMenuItem(_("Launch using Dedicated Graphics Card"));
+                 this._onDiscreteGpuMenuItem.connect('activate', () => {
+Index: gnome-shell/src/shell-util.c
+===================================================================
+--- gnome-shell.orig/src/shell-util.c	2020-04-20 11:04:36.062327680 -0600
++++ gnome-shell/src/shell-util.c	2020-04-20 11:06:59.515758370 -0600
+@@ -408,8 +408,8 @@
+ 
+ typedef const gchar *(*ShellGLGetString) (GLenum);
+ 
+-static const gchar *
+-get_gl_vendor (void)
++const gchar *
++shell_util_get_gl_vendor (void)
+ {
+   static const gchar *vendor = NULL;
+ 
+@@ -430,7 +430,7 @@
+   if (!clutter_check_windowing_backend (CLUTTER_WINDOWING_X11))
+     return FALSE;
+ 
+-  if (g_strcmp0 (get_gl_vendor (), "NVIDIA Corporation") == 0)
++  if (g_strcmp0 (shell_util_get_gl_vendor (), "NVIDIA Corporation") == 0)
+     return TRUE;
+ 
+   return FALSE;
+Index: gnome-shell/src/shell-util.h
+===================================================================
+--- gnome-shell.orig/src/shell-util.h	2020-04-20 11:04:36.062327680 -0600
++++ gnome-shell/src/shell-util.h	2020-04-20 11:06:35.672168190 -0600
+@@ -49,6 +49,8 @@
+                                                int                height,
+                                                int                rowstride);
+ 
++const gchar *shell_util_get_gl_vendor (void);
++
+ gboolean shell_util_need_background_refresh (void);
+ 
+ ClutterContent * shell_util_get_content_for_window_actor (MetaWindowActor *window_actor,

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -49,3 +49,4 @@ ubuntu/secure_mode_extension.patch
 ubuntu/keep-ubuntu-logo-bright-lp1867133-v1.patch
 sched-rr.patch
 pop-dark-theme.patch
+ignore-nvidia-only.patch


### PR DESCRIPTION
If GNOME Shell if backed by NVIDIA, don't show the "Launch using Dedicated Graphics Card" item.