### PR TITLE
Rename `Show the overview` to `Show workspaces`

### DIFF
--- a/debian/patches/pop-cosmic-keyboard-shortcuts.patch
+++ b/debian/patches/pop-cosmic-keyboard-shortcuts.patch
@@ -1,0 +1,28 @@
+Index: gnome-shell/data/50-gnome-shell-system.xml
+===================================================================
+--- gnome-shell.orig/data/50-gnome-shell-system.xml
++++ gnome-shell/data/50-gnome-shell-system.xml
+@@ -12,7 +12,7 @@
+                       description="Focus the active notification"/>
+ 
+ 	<KeyListEntry name="toggle-overview"
+-                      description="Show the overview"/>
++                      description="Show workspaces"/>
+ 
+ 	<KeyListEntry name="toggle-application-view"
+                       description="Show all applications"/>
+Index: gnome-shell/po/en_GB.po
+===================================================================
+--- gnome-shell.orig/po/en_GB.po
++++ gnome-shell/po/en_GB.po
+@@ -35,8 +35,8 @@
+ msgstr "Focus the active notification"
+ 
+ #: data/50-gnome-shell-system.xml:15
+-msgid "Show the overview"
+-msgstr "Show the overview"
++msgid "Show workspaces"
++msgstr "Show workspaces"
+ 
+ #: data/50-gnome-shell-system.xml:18
+ msgid "Show all applications"

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -44,3 +44,4 @@ calendar-server-Fix-double-free-detection-abort.patch
 sched-rr.patch
 pop-dark-theme.patch
 ignore-nvidia-only.patch
+pop-cosmic-keyboard-shortcuts.patch


### PR DESCRIPTION
Fixes https://github.com/pop-os/gnome-control-center/issues/166.

This is the current shortcut. The legacy shortcut is defined in Mutter (see https://github.com/pop-os/mutter/pull/22.)