### PR TITLE
fix: autologin issue by removing assumptions about when a monitor will be available

### DIFF
--- a/debian/patches/remove-assumptions-about-monitor-availability.patch
+++ b/debian/patches/remove-assumptions-about-monitor-availability.patch
@@ -1,0 +1,38 @@
+Index: gnome-shell/js/ui/layout.js
+===================================================================
+--- gnome-shell.orig/js/ui/layout.js
++++ gnome-shell/js/ui/layout.js
+@@ -352,8 +352,7 @@ var LayoutManager = GObject.registerClas
+             this.bottomMonitor = this.monitors[this.bottomIndex];
+ 
+             if (this._pendingLoadBackground) {
+-                this._loadBackground();
+-                this._pendingLoadBackground = false;
++                this._pendingLoadBackground = this._loadBackground() ? true : false;
+             }
+         } else {
+             this.primaryMonitor = null;
+@@ -616,13 +615,19 @@ var LayoutManager = GObject.registerClas
+             // This helps to prevent us from running the animation
+             // when the system is bogged down
+             const id = GLib.idle_add(GLib.PRIORITY_LOW, () => {
+-                this._systemBackground.show();
+-                global.stage.show();
+-                this._prepareStartupAnimation();
+-                return GLib.SOURCE_REMOVE;
++                if (this.primaryMonitor) {
++                    this._systemBackground.show();
++                    global.stage.show();
++                    this._prepareStartupAnimation();
++                    return GLib.SOURCE_REMOVE;
++                } else {
++                    return GLib.SOURCE_CONTINUE;
++                }
++
+             });
+             GLib.Source.set_name_by_id(id, '[gnome-shell] Startup Animation');
+         });
++        return true;
+     }
+ 
+     // Startup Animations

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
+remove-assumptions-about-monitor-availability.patch
 debian/gnome-shell-extension-prefs-Give-Debian-specific-advice.patch
 ubuntu/desktop_detect.patch
 ubuntu/lightdm-user-switching.patch


### PR DESCRIPTION
This does the heavy lifting, but is intended to be merged with pop-os/cosmic-workspaces#41

This changes the way that gnome-shell initializes itself. So this should probably be tested pretty heavily. Mostly with monitor use cases.

Something that should be tested is computer performance when *no* monitor is plugged in. The keeps the gnome-shell startup animation in a `Glib` loop until a monitor is ready. It should be checked if there is a noticeable headless performance degradation.