### PR TITLE
fix: Prevent notifications disappearing on app focus

### DIFF
--- a/debian/patches/pop-notification-focus.patch
+++ b/debian/patches/pop-notification-focus.patch
@@ -1,0 +1,37 @@
+Index: gnome-shell/js/ui/notificationDaemon.js
+===================================================================
+--- gnome-shell.orig/js/ui/notificationDaemon.js
++++ gnome-shell/js/ui/notificationDaemon.js
+@@ -34,11 +34,6 @@ var FdoNotificationDaemon = class FdoNot
+         this._notifications = {};
+ 
+         this._nextNotificationId = 1;
+-
+-        Shell.WindowTracker.get_default().connect('notify::focus-app',
+-            this._onFocusAppChanged.bind(this));
+-        Main.overview.connect('hidden',
+-            this._onFocusAppChanged.bind(this));
+     }
+ 
+     _imageForNotificationData(hints) {
+@@ -326,20 +321,6 @@ var FdoNotificationDaemon = class FdoNot
+         ];
+     }
+ 
+-    _onFocusAppChanged() {
+-        let tracker = Shell.WindowTracker.get_default();
+-        if (!tracker.focus_app)
+-            return;
+-
+-        for (let i = 0; i < this._sources.length; i++) {
+-            let source = this._sources[i];
+-            if (source.app == tracker.focus_app) {
+-                source.destroyNonResidentNotifications();
+-                return;
+-            }
+-        }
+-    }
+-
+     _emitNotificationClosed(id, reason) {
+         this._dbusImpl.emit_signal('NotificationClosed',
+                                    GLib.Variant.new('(uu)', [id, reason]));

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -32,3 +32,4 @@ pop-dark-theme.patch
 ignore-nvidia-only.patch
 pop-cosmic-keyboard-shortcuts.patch
 remove-assumptions-about-monitor-availability.patch
+pop-notification-focus.patch


### PR DESCRIPTION
Fixes notifications disappearing when an application is focused. Such as Firefox notifications.
[Cinnamon did the same thing 4 years ago](https://github.com/linuxmint/Cinnamon/commit/65c4cc1e0469b32e685c3029dc6b1df2d45e9a09)
