### PR TITLE
fix: Undefined record for window causing backtrace

### DIFF
--- a/debian/patches/series
+++ b/debian/patches/series
@@ -33,3 +33,4 @@ ignore-nvidia-only.patch
 pop-cosmic-keyboard-shortcuts.patch
 remove-assumptions-about-monitor-availability.patch
 greeter-exception.patch
+undefined-record.patch

--- a/debian/patches/undefined-record.patch
+++ b/debian/patches/undefined-record.patch
@@ -1,0 +1,14 @@
+Index: gnome-shell/js/ui/workspaceAnimation.js
+===================================================================
+--- gnome-shell.orig/js/ui/workspaceAnimation.js
++++ gnome-shell/js/ui/workspaceAnimation.js
+@@ -78,6 +78,9 @@ class WorkspaceGroup extends Clutter.Act
+         for (const windowActor of windowActors) {
+             const record = this._windowRecords.find(r => r.windowActor === windowActor);
+ 
++            /// The window my not have a record.
++            if (!record) continue
++
+             this.set_child_above_sibling(record.clone,
+                 lastRecord ? lastRecord.clone : bottomActor);
+             lastRecord = record;


### PR DESCRIPTION
As seen in https://github.com/pop-os/gnome-shell/issues/112, fixes this backtrace which could be breaking other behavior in the shell:

```
JS ERROR: TypeError: record is undefined
_syncStacking@resource:///org/gnome/shell/ui/workspaceAnimation.js:81:13
```