### PR TITLE
Fix package version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+gnome-shell (42.5-0ubuntu1pop1) jammy; urgency=medium
+
+  * Fix package version
+
+ -- Brock <brock@pop-os.localdomain>  Wed, 08 Feb 2023 22:23:57 -0700
+
 gnome-shell (42.5-0ubuntu1) jammy; urgency=medium
 
   * New upstream release (LP: #1993809)


### PR DESCRIPTION
In a recent rebase the package version was set incorrectly. This is causing some machines. (Particularly the arm64 pi ISO) to require the `--allow-downgrades` flag on package updates.

This bumps the version number, so dpkg should now see the update as an upgrade, not a downgrade.